### PR TITLE
Fix issue with colon detection in German

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -82,7 +82,7 @@ class EmailReplyParser
 
       # Normalize line endings.
       text.gsub!("\r\n", "\n")
-      
+
       # Check for multi-line reply headers. Some clients break up
       # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
       MULTILINE_QUOTE_HEADER_EXPRESSIONS.each do |expr|
@@ -146,9 +146,9 @@ class EmailReplyParser
       # French
       /(?!Le.*Le\s.+?a écrit[a-zA-Z0-9.:;<>()&@ -]*:)(Le\s(.+?)a écrit[a-zA-Z0-9.:;<>()&@ -]*:)/m,
       # German
-      /(?!Am.*Am\s.+?schrieb.*:)(Am\s(.+?)schrieb.*:)/m,
+      /(?!Am.*Am\s.+?schrieb[^:]*:)(Am\s(.+?)schrieb[^:]*:)/m,
       # Italian
-      /(?!Il.*Il\s.+?scritto.*:)(Il[\s\S]+?(.+?)scritto:)/m
+      /(?!Il.*Il\s.+?scritto[^:]*:)(Il[\s\S]+?(.+?)scritto:)/m
     ].freeze
     QUOTE_HEADER_REGULAR_EXPRESSIONS = [
       # English
@@ -161,7 +161,7 @@ class EmailReplyParser
       /Le.*a écrit.*[> ]:$/m,
       /^(De|A|Envoyé|Objet)\s*:.*$/m,
       # German
-      /[a-zA-Z]{2,5}.*schrieb.*:$/,
+      /[a-zA-Z]{2,5}.*schrieb[^:]*:$/,
       # Italian
       /^Il.+?ha scritto:$/
     ].freeze

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -225,7 +225,7 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal [false, true], reply.fragments.map { |f| f.quoted? }
     assert_equal [false, false], reply.fragments.map { |f| f.signature? }
   end
- 
+
   def test_quote_reply_spanish_multiline
     reply = email("quote_reply_spanish_multiline")
     assert_equal("This is a reply with Spanish quote multiline", reply.fragments[0].to_s)

--- a/test/emails/quote_reply_french_multiline.txt
+++ b/test/emails/quote_reply_french_multiline.txt
@@ -3,5 +3,6 @@ This is a reply with French quote multiline
 Le mer. 29 juin 2022 =C3=A0 12:32, Rick Sanchez <rick.sanchez.mail@example.com=
 > a écrit :
 
-> Hello this is a test
+> Hello this is a test:
+> test
 >

--- a/test/emails/quote_reply_german_multiline.txt
+++ b/test/emails/quote_reply_german_multiline.txt
@@ -3,5 +3,6 @@ This is a reply with German quote multiline
 Am Mo., 4. Juli 2022 um 08:13 Uhr schrieb Rick Sanchez <
 rick.sanchez@example.com>:
 
-> Hello this is a test
+> Hello this is a test:
+> test
 >

--- a/test/emails/quote_reply_italian_multiline.txt
+++ b/test/emails/quote_reply_italian_multiline.txt
@@ -4,5 +4,6 @@ Il giorno lun 4 lug 2022 alle ore 08:12 Rick Sanchez <rick@example.co=
 m>
 ha scritto:
 
-> Hello this is a test
+> Hello this is a test:
+> test
 >

--- a/test/emails/quote_reply_spanish_multiline.txt
+++ b/test/emails/quote_reply_spanish_multiline.txt
@@ -4,5 +4,6 @@ El mié, 29 jun 2022 a las 11:08, Rick Sanchez (<rick.sanchez.email@exampl=
 e.com>)
 escribió:
 
-> Hello this is a test
+> Hello this is a test:
+> test
 >


### PR DESCRIPTION
When the quoted content includes a colon, the detection of a German header gets broke. This PR fixes that.