### PR TITLE
fix: Quote parser for portuguese

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -148,7 +148,9 @@ class EmailReplyParser
       # German
       /(?!Am.*Am\s.+?schrieb[^:]*:)(Am\s(.+?)schrieb[^:]*:)/m,
       # Italian
-      /(?!Il.*Il\s.+?scritto[^:]*:)(Il[\s\S]+?(.+?)scritto:)/m
+      /(?!Il.*Il\s.+?scritto[^:]*:)(Il[\s\S]+?(.+?)scritto:)/m,
+      # Portuguese
+      /(?!Em.*Em\s.+?escreveu\s*:)(Em[\s\S]+?escre[a-zA-Z=\s]*:)/m
     ].freeze
     QUOTE_HEADER_REGULAR_EXPRESSIONS = [
       # English
@@ -163,7 +165,10 @@ class EmailReplyParser
       # German
       /[a-zA-Z]{2,5}.*schrieb[^:]*:$/,
       # Italian
-      /^Il.+?ha scritto:$/
+      /^Il.+?ha scritto:$/,
+      # Portuguese
+      /^Em.+?escre[a-zA-Z=\s]*:$/m,
+      /^(De|Enviado|Para|Assunto):.*$/m
     ].freeze
 
     ### Line-by-Line Parsing

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -288,6 +288,22 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal [false, false], reply.fragments.map { |f| f.signature? }
   end
 
+  def test_quote_reply_portuguese
+    reply = email('quote_reply_portuguese')
+    assert_equal('This is a reply with Portuguese quote', reply.fragments[0].to_s)
+    assert_equal [false, true], reply.fragments.map(&:hidden?)
+    assert_equal [false, true], reply.fragments.map(&:quoted?)
+    assert_equal [false, false], reply.fragments.map(&:signature?)
+  end
+
+  def test_quote_reply_portuguese_multiline
+    reply = email('quote_reply_portuguese_multiline')
+    assert_equal('This is a reply with Portuguese quote multiline', reply.fragments[0].to_s)
+    assert_equal [false, true, true], reply.fragments.map(&:hidden?)
+    assert_equal [false, true, false], reply.fragments.map(&:quoted?)
+    assert_equal [false, false, false], reply.fragments.map(&:signature?)
+  end
+
   def test_pathological_emails
     t0 = Time.now
     email("pathological")

--- a/test/emails/quote_reply_portuguese.txt
+++ b/test/emails/quote_reply_portuguese.txt
@@ -1,0 +1,6 @@
+This is a reply with Portuguese quote
+
+Em qui., 20 de out. de 2022 =C3=A0s 09:36, Rick <rick@example.com> escreveu:
+
+> Hello this is a test
+>

--- a/test/emails/quote_reply_portuguese_multiline.txt
+++ b/test/emails/quote_reply_portuguese_multiline.txt
@@ -1,0 +1,8 @@
+This is a reply with Portuguese quote multiline
+
+Em qui., 20 de out. de 2022 =C3=A0s 09:37, Rick <rick@example.com> escre=
+veu:
+
+> Hello this is a test:
+> test
+>


### PR DESCRIPTION
Emails from clients in Portuguese were not striping the right content. I added another regex to match portuguese quote.